### PR TITLE
Support single-tilde (~text~) strikethrough in markdown notes

### DIFF
--- a/cli/autumn_cli/utils/log_render.py
+++ b/cli/autumn_cli/utils/log_render.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from datetime import datetime
+import re
 from textwrap import wrap
 from typing import Dict, Any, Iterable, List, Optional, Union
 
@@ -27,6 +28,9 @@ from .formatters import (
 
 from rich.markup import escape as rich_escape
 from rich.markdown import Markdown
+
+
+_SINGLE_TILDE_STRIKE = re.compile(r"(?<!~)~([^~\n]+)~(?!~)")
 
 
 def _normalize_ws(text: str) -> str:
@@ -189,6 +193,10 @@ def render_sessions_list(
         can show clickable links.
         """
 
+        # Rich/CommonMark supports strikethrough with double tildes (~~text~~).
+        # For convenience and backward compatibility with older note habits,
+        # normalize single-tilde markers (~text~) into CommonMark form.
+        note = _SINGLE_TILDE_STRIKE.sub(r"~~\1~~", note)
         return Markdown(note, style="autumn.note")
 
     sessions_list = list(sessions)

--- a/cli/tests/test_formatters.py
+++ b/cli/tests/test_formatters.py
@@ -90,3 +90,27 @@ def test_status_matches_old_style_without_end_and_with_duration():
     assert " ago" in rendered
     assert "2h" in rendered and "5m" in rendered
     assert "End" not in rendered
+
+
+def test_markdown_notes_support_single_tilde_strikethrough():
+    sessions = [
+        {
+            "id": 5,
+            "project": "Project A",
+            "subprojects": [],
+            "start_time": "2026-01-01T10:00:00",
+            "end_time": "2026-01-01T11:00:00",
+            "duration_minutes": 60,
+            "note": "before ~removed~ after",
+        }
+    ]
+
+    with _plain_console.capture() as capture:
+        for item in render_sessions_list(sessions, markdown_notes=True):
+            _plain_console.print(item)
+    rendered = capture.get()
+
+    # Terminal text still includes the content; we mainly verify this doesn't
+    # render literal single-tilde markers in markdown mode.
+    assert "before removed after" in rendered
+    assert "~removed~" not in rendered


### PR DESCRIPTION
### Motivation
- Users sometimes write strikethrough with single tildes (`~text~`) but the renderer expects CommonMark double tildes (`~~text~~`), so notes containing single-tilde strikes were rendered verbatim instead of as strike-through.

### Description
- Add an `re` pattern `_SINGLE_TILDE_STRIKE` and normalize `~text~` to `~~text~~` before creating the Rich `Markdown` renderable in `cli/autumn_cli/utils/log_render.py`.
- Import `re` and apply the substitution inside the helper used for markdown notes (`_markdown_note_renderable`).
- Add a unit test `test_markdown_notes_support_single_tilde_strikethrough` in `cli/tests/test_formatters.py` that exercises `render_sessions_list(..., markdown_notes=True)` with a `note` containing `~removed~`.

### Testing
- Ran `cd cli && pytest -q tests/test_formatters.py`; test collection failed with `ModuleNotFoundError: No module named 'rich'` in this environment so the added test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34dfecfb0833389d863334668270e)